### PR TITLE
[Release] 2.0.0 alpha.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  unit:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: npm
+    - name: Install modules
+      run: npm install
+    - name: Run tests
+      run: npm run test -- --coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Add support for both `-c` or `-l` flag from the Prettier command ([741f555](https://github.com/studiometa/prettier-formatter-gitlab/commit/741f555))
+
 ## v2.0.0-alpha.0 - 2024.04.15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## v2.0.0-alpha.1 - 2024.04.16
+
 ### Added
 
 - Add support for both `-c` or `-l` flag from the Prettier command ([741f555](https://github.com/studiometa/prettier-formatter-gitlab/commit/741f555))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/prettier-formatter-gitlab",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/prettier-formatter-gitlab",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/prettier-formatter-gitlab",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "description": "A Prettier formatter for the GitLab Code Quality report",
   "main": "src/index.js",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ const {
   CI_CONFIG_PATH = '.gitlab-ci.yml',
   CI_JOB_NAME,
   CI_PROJECT_DIR = cwd(),
-  PRETTIER_CODE_QUALITY_REPORT,
 } = env;
 
 /**
@@ -39,9 +38,14 @@ function getOutputPath() {
  */
 function parse(results) {
   return results
-    .toString()
     .split('\n')
-    .filter((line) => line);
+    .filter(
+      (line) =>
+        Boolean(line) &&
+        !line.startsWith('Checking formatting...') &&
+        !line.includes('Code style issues found'),
+    )
+    .map((line) => line.replace('[warn] ', ''));
 }
 
 /**
@@ -50,6 +54,7 @@ function parse(results) {
  * @returns {Promise<void>}
  */
 export async function prettierFormatterGitLab(results) {
+  const { PRETTIER_CODE_QUALITY_REPORT } = env;
   if (CI_JOB_NAME || PRETTIER_CODE_QUALITY_REPORT) {
     const files = parse(results);
 

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -1,6 +1,7 @@
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect, afterEach, spyOn } from 'bun:test';
 import { existsSync, unlinkSync, readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
+import { prettierFormatterGitLab } from '../src/index.js';
 
 const CODE_QUALITY_FILENAME = 'gl-prettier-codequality.json';
 
@@ -23,5 +24,29 @@ describe('prettier-formatter-gitlab cli', () => {
     expect(existsSync(CODE_QUALITY_FILENAME)).toBe(true);
     const content = readFileSync(CODE_QUALITY_FILENAME);
     expect(content.toString()).toMatchSnapshot();
+  });
+
+  it('should work with the `-c` or `-l` flag', async () => {
+    const consoleSpy = spyOn(console, 'log');
+    consoleSpy.mockImplementation(() => null);
+    process.env.PRETTIER_CODE_QUALITY_REPORT = CODE_QUALITY_FILENAME;
+
+    // prettier -c path/to/folder/
+    const outputCheck = `Checking formatting...
+[warn] test/dirty-2.js
+[warn] test/dirty.js
+[warn] Code style issues found in 3 files. Run Prettier to fix.
+`;
+
+    // prettier -l path/to/folder/
+    const outputList = `test/dirty-2.js
+test/dirty.js
+`;
+
+    await prettierFormatterGitLab(outputCheck);
+    await prettierFormatterGitLab(outputList);
+    expect(consoleSpy).toHaveBeenCalledTimes(12);
+    expect(consoleSpy.mock.calls.slice(0, 6)).toEqual(consoleSpy.mock.calls.slice(6, 12));
+    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
### Added

- Add support for both `-c` or `-l` flag from the Prettier command ([741f555](https://github.com/studiometa/prettier-formatter-gitlab/commit/741f555))