### PR TITLE
[Release] 2.1.0-alpha.1

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: macos-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## v2.1.0-alpha.1 - 2024.12.11
+
+### Fixed
+
+- Fix NPM publish ([b5cee7b](https://github.com/studiometa/prettier-formatter-gitlab/commit/b5cee7b))
+
+### Dependencies
+
+- Update dependency prettier to v3.4.2 ([#38](https://github.com/studiometa/prettier-formatter-gitlab/pull/38), [2139c1c](https://github.com/studiometa/prettier-formatter-gitlab/commit/2139c1c))
+- Update dependency @studiometa/eslint-config to v4.1.0 ([#32](https://github.com/studiometa/prettier-formatter-gitlab/pull/32), [3b4cc1c](https://github.com/studiometa/prettier-formatter-gitlab/commit/3b4cc1c))
+
 ## v2.1.0-alpha.0 - 2024.12.11
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/prettier-formatter-gitlab",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/prettier-formatter-gitlab",
-      "version": "2.1.0-alpha.0",
+      "version": "2.1.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "prettier-formatter-gitlab": "bin/cli.js"
       },
       "devDependencies": {
-        "@studiometa/eslint-config": "4.0.1",
+        "@studiometa/eslint-config": "4.1.0",
         "@studiometa/prettier-config": "4.1.0",
         "bun": "1.1.20",
         "eslint": "9.4.0",
@@ -493,9 +493,9 @@
       "license": "MIT"
     },
     "node_modules/@studiometa/eslint-config": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@studiometa/eslint-config/-/eslint-config-4.0.1.tgz",
-      "integrity": "sha512-vzB3n+0lKCcWkUXuPvQd0/Z0t2zgnl2pLuXRap9/qK5QhCd9rDDbcuIvTY8GGX4UhssRn6ZypEAMUdPQqAvH+A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@studiometa/eslint-config/-/eslint-config-4.1.0.tgz",
+      "integrity": "sha512-tTGlQ+n87bvIxhKI5woC6gsis+PgBhb77VdLTSEpo1cnL0Glsf14GADT3ftPGLwADc9bPMylmmgNkDW6LyRNyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@studiometa/prettier-config": "4.1.0",
         "bun": "1.1.37",
         "eslint": "9.4.0",
-        "prettier": "3.3.3"
+        "prettier": "3.4.2"
       },
       "peerDependencies": {
         "prettier": "^3.0"
@@ -2463,9 +2463,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@studiometa/prettier-config": "4.1.0",
     "bun": "1.1.37",
     "eslint": "9.4.0",
-    "prettier": "3.3.3"
+    "prettier": "3.4.2"
   },
   "dependencies": {
     "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/studiometa/prettier-formatter-gitlab#readme",
   "devDependencies": {
-    "@studiometa/eslint-config": "4.0.1",
+    "@studiometa/eslint-config": "4.1.0",
     "@studiometa/prettier-config": "4.1.0",
     "bun": "1.1.20",
     "eslint": "9.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/prettier-formatter-gitlab",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "description": "A Prettier formatter for the GitLab Code Quality report",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
### Fixed

- Fix NPM publish ([b5cee7b](https://github.com/studiometa/prettier-formatter-gitlab/commit/b5cee7b))

### Dependencies

- Update dependency prettier to v3.4.2 ([#38](https://github.com/studiometa/prettier-formatter-gitlab/pull/38), [2139c1c](https://github.com/studiometa/prettier-formatter-gitlab/commit/2139c1c))
- Update dependency @studiometa/eslint-config to v4.1.0 ([#32](https://github.com/studiometa/prettier-formatter-gitlab/pull/32), [3b4cc1c](https://github.com/studiometa/prettier-formatter-gitlab/commit/3b4cc1c))
