### PR TITLE
Update CI to use main branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,7 @@ name: tests
 on:
   push:
     branches:
-      - master
-      - develop
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Migrate from git-flow (master/develop) to trunk-based (main).

- Replace master/develop branch triggers with main in tests workflow
- Default branch already changed to main
- Open PRs retargeted to main

Co-authored-by: Claude <claude@anthropic.com>